### PR TITLE
Improve description of comparision with other activities

### DIFF
--- a/docs/assets/template-for-community-application.txt
+++ b/docs/assets/template-for-community-application.txt
@@ -35,7 +35,7 @@ These descriptions will be displayed on the organization list page (Short Descri
   - Open source license:
 
 
-## Application Questionaire
+## Application Questionnaire
 
 1. What would you like to gain from "Summer 2021"?
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,9 +19,9 @@ Summer 2021 of Open Source Promotion Plan (hereinafter referred to as summer 202
 
 Students can choose the projects they are interested in to apply, and obtain the opportunity of the senior maintainer (community mentor) to guide them. According to the difficulty and completion of the project, participants will also receive the bonus of "Summer 2021 of Open Source Promotion Plan" .
 
-## What is different from other Summer of Code activity
+## What is different from other Summer of Code activities
 
-Inspired by other Summer of Code activities, this event hopes to further promote the development of open source communities.
+Inspired by other Summer of Code activities, this event hopes to further promote the development of open source communities, and the main highlights reflect as follows:
 
 1. The difficulty range of supporting projects is wider
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,11 +19,9 @@ Summer 2021 of Open Source Promotion Plan (hereinafter referred to as summer 202
 
 Students can choose the projects they are interested in to apply, and obtain the opportunity of the senior maintainer (community mentor) to guide them. According to the difficulty and completion of the project, participants will also receive the bonus of "Summer 2021 of Open Source Promotion Plan" .
 
-## What is different from GSoC
+## What is different from other Summer of Code activity
 
-Inspired by Google Summer of Code (GSoC), this event hopes to further promote the development of open source communities in China.
-
-According to the specific situation in China, this activity is different from GSoC in the following aspects:
+Inspired by other Summer of Code activities, this event hopes to further promote the development of open source communities.
 
 1. The difficulty range of supporting projects is wider
 


### PR DESCRIPTION
To prevent unnecessary misunderstanding, we should remove specific name of other activity.